### PR TITLE
#254 Prevents a null exception when there is no version.

### DIFF
--- a/src/App.Metrics.AspNetCore.Mvc/MvcRouteTemplateResolver.cs
+++ b/src/App.Metrics.AspNetCore.Mvc/MvcRouteTemplateResolver.cs
@@ -69,7 +69,8 @@ namespace Microsoft.AspNetCore.Mvc.Internal
         {
             var routeTemplate = actionDescriptor.AttributeRouteInfo?.Template.ToLower() ?? string.Empty;
 
-            if (actionDescriptor.Properties != null && actionDescriptor.Properties.ContainsKey(MsVersionpolicyIsAppliedToken))
+            if (actionDescriptor.Properties != null && actionDescriptor.Properties.ContainsKey(MsVersionpolicyIsAppliedToken)
+                && routeData.Values.ContainsKey(VersionRouteDataToken))
             {
                 routeTemplate = routeTemplate.Replace(ApiVersionToken, routeData.Values[VersionRouteDataToken].ToString());
             }


### PR DESCRIPTION
### The issue or feature being addressed

[GitHub Issue](https://github.com/AppMetrics/AppMetrics/issues/254) -- When using [ApiVersionNeutral] a null exception is thrown.

### Details on the issue fix or feature implementation

Adds a simple check to verify that there is in fact a VersionRouteDataToken before attempting to access it from the dictionary.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [X] I have included the github issue number in my commits 
- [ ] I have included unit tests for the issue/feature 
I am unsure how to add this to your current test framework given that it requires use of `Microsoft.AspNetCore.Mvc.Versioning` which would subsequently require it in the TestController. Perhaps you could give me some guidance on where/how you'd like this to be done.