### PR TITLE
WebHost AllEndpointsPort should bind to 0.0.0.0, not just localhost

### DIFF
--- a/src/App.Metrics.AspNetCore.Endpoints/Builder/MetricsAspNetEndpointWebHostBuilderExtensions.cs
+++ b/src/App.Metrics.AspNetCore.Endpoints/Builder/MetricsAspNetEndpointWebHostBuilderExtensions.cs
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Hosting
             if (ports.Any())
             {
                 var existingUrl = hostBuilder.GetSetting(WebHostDefaults.ServerUrlsKey);
-                var additionalUrls = string.Join(";", ports.Distinct().Select(p => $"http://localhost:{p}/"));
+                var additionalUrls = string.Join(";", ports.Distinct().Select(p => $"http://*:{p}/"));
                 hostBuilder.UseSetting(WebHostDefaults.ServerUrlsKey, $"{existingUrl};{additionalUrls}");
             }
 


### PR DESCRIPTION
This pull request addresses issue #28

Configuring endpoints with AllEndpointsPort for alternate port binds only to localhost, not 0.0.0.0, when using WebHost.  The fix is to use the marker "*" instead of the name "localhost".
