### PR TITLE
Improve performance of ignored routes workflow

### DIFF
--- a/AspNetCore.sln
+++ b/AspNetCore.sln
@@ -84,6 +84,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetricsReportingSandboxMvc"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App.Metrics.AspNetCore.Mvc.Core", "src\App.Metrics.AspNetCore.Mvc.Core\App.Metrics.AspNetCore.Mvc.Core.csproj", "{8FC832BB-1EDB-43E6-9844-05CB949ADCA7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Metrics.AspNetCore.Tracking.Facts", "test\App.Metrics.AspNetCore.Tracking.Facts\App.Metrics.AspNetCore.Tracking.Facts.csproj", "{32DD796A-48CD-4622-B0A1-B889A4661D88}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -146,6 +148,10 @@ Global
 		{8FC832BB-1EDB-43E6-9844-05CB949ADCA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FC832BB-1EDB-43E6-9844-05CB949ADCA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8FC832BB-1EDB-43E6-9844-05CB949ADCA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32DD796A-48CD-4622-B0A1-B889A4661D88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32DD796A-48CD-4622-B0A1-B889A4661D88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32DD796A-48CD-4622-B0A1-B889A4661D88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32DD796A-48CD-4622-B0A1-B889A4661D88}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -169,6 +175,7 @@ Global
 		{63F67AF0-939C-4E32-A901-405F4E8E405E} = {2D805782-756E-4C98-B22E-F502BEE95318}
 		{6B54766A-C439-47AB-B44A-887396E203E5} = {C0BC96C5-46E1-4323-9C5D-58D9A96549CD}
 		{8FC832BB-1EDB-43E6-9844-05CB949ADCA7} = {2D805782-756E-4C98-B22E-F502BEE95318}
+		{32DD796A-48CD-4622-B0A1-B889A4661D88} = {DD2E4647-7125-4CE3-9BA5-B45A26113A31}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8699A1D-0BA1-403C-86E9-C789CD2645EB}

--- a/src/App.Metrics.AspNetCore.Tracking/Builder/MetricsMiddlewareApplicationBuilderExtensions.cs
+++ b/src/App.Metrics.AspNetCore.Tracking/Builder/MetricsMiddlewareApplicationBuilderExtensions.cs
@@ -70,15 +70,15 @@ namespace Microsoft.AspNetCore.Builder
             EnsureRequiredServices(app);
 
             var metricsOptions = app.ApplicationServices.GetRequiredService<MetricsOptions>();
-            var trackingMiddlwareOptionsAccessor = app.ApplicationServices.GetRequiredService<IOptions<MetricsWebTrackingOptions>>();
+            var trackingMiddlewareOptionsAccessor = app.ApplicationServices.GetRequiredService<IOptions<MetricsWebTrackingOptions>>();
 
             app.UseWhen(
-                context => !IsNotAnIgnoredRoute(trackingMiddlwareOptionsAccessor.Value.IgnoredRoutesRegex, context.Request.Path) &&
-                           metricsOptions.Enabled &&
-                           trackingMiddlwareOptionsAccessor.Value.ApdexTrackingEnabled,
+                context => metricsOptions.Enabled &&
+                           trackingMiddlewareOptionsAccessor.Value.ApdexTrackingEnabled &&
+                           !IsNotAnIgnoredRoute(trackingMiddlewareOptionsAccessor.Value.IgnoredRoutesRegex, context.Request.Path),
                 appBuilder =>
                 {
-                    if (trackingMiddlwareOptionsAccessor.Value.ApdexTrackingEnabled)
+                    if (trackingMiddlewareOptionsAccessor.Value.ApdexTrackingEnabled)
                     {
                         appBuilder.UseMiddleware<ApdexMiddleware>();
                     }
@@ -113,15 +113,15 @@ namespace Microsoft.AspNetCore.Builder
         {
             EnsureRequiredServices(app);
 
-            var trackingMiddlwareOptionsAccessor = app.ApplicationServices.GetRequiredService<IOptions<MetricsWebTrackingOptions>>();
+            var trackingMiddlewareOptionsAccessor = app.ApplicationServices.GetRequiredService<IOptions<MetricsWebTrackingOptions>>();
 
             app.UseWhen(
-                context => !IsNotAnIgnoredRoute(trackingMiddlwareOptionsAccessor.Value.IgnoredRoutesRegex, context.Request.Path) &&
-                           context.OAuthClientId().IsPresent() &&
-                           trackingMiddlwareOptionsAccessor.Value.OAuth2TrackingEnabled,
+                context => context.OAuthClientId().IsPresent() &&
+                           trackingMiddlewareOptionsAccessor.Value.OAuth2TrackingEnabled &&
+                           !IsNotAnIgnoredRoute(trackingMiddlewareOptionsAccessor.Value.IgnoredRoutesRegex, context.Request.Path),
                 appBuilder =>
                 {
-                    if (trackingMiddlwareOptionsAccessor.Value.OAuth2TrackingEnabled)
+                    if (trackingMiddlewareOptionsAccessor.Value.OAuth2TrackingEnabled)
                     {
                         appBuilder.UseMiddleware<OAuthTrackingMiddleware>();
                     }
@@ -186,11 +186,11 @@ namespace Microsoft.AspNetCore.Builder
         private static void UseMetricsMiddleware<TMiddleware>(
             IApplicationBuilder app,
             MetricsOptions metricsOptions,
-            IOptions<MetricsWebTrackingOptions> trackingMiddlwareOptionsAccessor)
+            IOptions<MetricsWebTrackingOptions> trackingMiddlewareOptionsAccessor)
         {
             app.UseWhen(
-                context => !IsNotAnIgnoredRoute(trackingMiddlwareOptionsAccessor.Value.IgnoredRoutesRegex, context.Request.Path) &&
-                           metricsOptions.Enabled,
+                context => metricsOptions.Enabled &&
+                           !IsNotAnIgnoredRoute(trackingMiddlewareOptionsAccessor.Value.IgnoredRoutesRegex, context.Request.Path),
                 appBuilder =>
                 {
                     if (metricsOptions.Enabled)

--- a/src/App.Metrics.AspNetCore.Tracking/IgnoredRoutesConfiguration.cs
+++ b/src/App.Metrics.AspNetCore.Tracking/IgnoredRoutesConfiguration.cs
@@ -1,0 +1,104 @@
+﻿// <copyright file="IgnoredRoutesConfiguration.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace App.Metrics.AspNetCore.Tracking
+{
+    internal class IgnoredRoutesConfiguration : IList<string>
+    {
+        private readonly List<string> _stringListImplementation;
+        private readonly List<Regex> _regexList;
+
+        public IgnoredRoutesConfiguration()
+            : this(new List<string>())
+        {
+        }
+
+        public IgnoredRoutesConfiguration(IList<string> patterns)
+        {
+            _stringListImplementation = patterns.ToList();
+            _regexList = _stringListImplementation.Select(GetRegex).ToList();
+        }
+
+        public IReadOnlyList<Regex> RegexPatterns => _regexList;
+
+        public IEnumerator<string> GetEnumerator() { return _stringListImplementation.GetEnumerator(); }
+
+        IEnumerator IEnumerable.GetEnumerator() { return ((IEnumerable)_stringListImplementation).GetEnumerator(); }
+
+        public void Add(string item)
+        {
+            _regexList.Add(GetRegex(item));
+            _stringListImplementation.Add(item);
+        }
+
+        public void Clear()
+        {
+            _regexList.Clear();
+            _stringListImplementation.Clear();
+        }
+
+        public bool Contains(string item)
+        {
+            return _stringListImplementation.Contains(item);
+        }
+
+        public void CopyTo(string[] array, int arrayIndex)
+        {
+            _stringListImplementation.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(string item)
+        {
+            var index = _stringListImplementation.IndexOf(item);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            _regexList.RemoveAt(index);
+            _stringListImplementation.RemoveAt(index);
+
+            return true;
+        }
+
+        public int Count => _stringListImplementation.Count;
+
+        public bool IsReadOnly => false;
+
+        public int IndexOf(string item)
+        {
+            return _stringListImplementation.IndexOf(item);
+        }
+
+        public void Insert(int index, string item)
+        {
+            _regexList.Insert(index, GetRegex(item));
+            _stringListImplementation.Insert(index, item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _regexList.RemoveAt(index);
+            _stringListImplementation.RemoveAt(index);
+        }
+
+        public string this[int index]
+        {
+            get => _stringListImplementation[index];
+            set
+            {
+                _stringListImplementation[index] = value;
+                _regexList[index] = GetRegex(value);
+            }
+        }
+
+        private static Regex GetRegex(string pattern) =>
+            new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    }
+}

--- a/src/App.Metrics.AspNetCore.Tracking/MetricsWebTrackingOptions.cs
+++ b/src/App.Metrics.AspNetCore.Tracking/MetricsWebTrackingOptions.cs
@@ -48,14 +48,15 @@ namespace App.Metrics.AspNetCore.Tracking
         /// </value>
         public IList<int> IgnoredHttpStatusCodes { get; set; } = new List<int>();
 
+        private IgnoredRoutesConfiguration _ignoredRoutesConfiguration = new IgnoredRoutesConfiguration();
+
         /// <summary>
         ///     Gets the ignored request routes where metrics should not be measured.
         /// </summary>
         /// <value>
         ///     The ignored routes regex patterns.
         /// </value>
-        public IReadOnlyList<Regex> IgnoredRoutesRegex =>
-            IgnoredRoutesRegexPatterns.Select(p => new Regex(p, RegexOptions.Compiled | RegexOptions.IgnoreCase)).ToList();
+        public IReadOnlyList<Regex> IgnoredRoutesRegex => _ignoredRoutesConfiguration.RegexPatterns;
 
         /// <summary>
         ///     Gets or sets the ignored request routes where metrics should not be measured.
@@ -63,7 +64,11 @@ namespace App.Metrics.AspNetCore.Tracking
         /// <value>
         ///     The ignored routes regex patterns.
         /// </value>
-        public IList<string> IgnoredRoutesRegexPatterns { get; set; } = new List<string>();
+        public IList<string> IgnoredRoutesRegexPatterns
+        {
+            get => _ignoredRoutesConfiguration;
+            set => _ignoredRoutesConfiguration = new IgnoredRoutesConfiguration(value);
+        }
 
         /// <summary>
         ///     Gets or sets a value indicating whether [oauth2 client tracking should be enabled], if disabled endpoint responds

--- a/test/App.Metrics.AspNetCore.Tracking.Facts/App.Metrics.AspNetCore.Tracking.Facts.csproj
+++ b/test/App.Metrics.AspNetCore.Tracking.Facts/App.Metrics.AspNetCore.Tracking.Facts.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(StandardTest)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\App.Metrics.AspNetCore.Tracking\App.Metrics.AspNetCore.Tracking.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/App.Metrics.AspNetCore.Tracking.Facts/MetricsWebTrackingOptionsTests.cs
+++ b/test/App.Metrics.AspNetCore.Tracking.Facts/MetricsWebTrackingOptionsTests.cs
@@ -2,7 +2,6 @@
 // Copyright (c) App Metrics Contributors. All rights reserved.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -18,7 +17,7 @@ namespace App.Metrics.AspNetCore.Tracking.Facts
             var options = new MetricsWebTrackingOptions();
 
             options.IgnoredRoutesRegexPatterns.Should().NotBeNull();
-            options.IgnoredRoutesRegexPatterns.Should().NotBeNull();
+            options.IgnoredRoutesRegex.Should().NotBeNull();
         }
 
         [Fact]
@@ -29,6 +28,8 @@ namespace App.Metrics.AspNetCore.Tracking.Facts
             var options = new MetricsWebTrackingOptions();
             options.IgnoredRoutesRegexPatterns = patterns;
 
+            options.IgnoredRoutesRegexPatterns
+                   .Should().BeEquivalentTo(patterns);
             options.IgnoredRoutesRegex.Select(r => r.ToString())
                    .Should().BeEquivalentTo(patterns);
         }
@@ -48,6 +49,8 @@ namespace App.Metrics.AspNetCore.Tracking.Facts
             options.IgnoredRoutesRegexPatterns[0] = "xyz";
 
             var expected = new List<string> { "xyz", "qwe", "route1" };
+            options.IgnoredRoutesRegexPatterns
+                   .Should().BeEquivalentTo(expected);
             options.IgnoredRoutesRegex.Select(r => r.ToString())
                    .Should().BeEquivalentTo(expected);
         }
@@ -60,6 +63,7 @@ namespace App.Metrics.AspNetCore.Tracking.Facts
 
             options.IgnoredRoutesRegexPatterns.Clear();
 
+            options.IgnoredRoutesRegexPatterns.Should().BeEmpty();
             options.IgnoredRoutesRegex.Should().BeEmpty();
         }
     }

--- a/test/App.Metrics.AspNetCore.Tracking.Facts/MetricsWebTrackingOptionsTests.cs
+++ b/test/App.Metrics.AspNetCore.Tracking.Facts/MetricsWebTrackingOptionsTests.cs
@@ -1,0 +1,66 @@
+// <copyright file="MetricsWebTrackingOptionsTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace App.Metrics.AspNetCore.Tracking.Facts
+{
+    public class MetricsWebTrackingOptionsTests
+    {
+        [Fact]
+        public void Patterns_and_regex_patterns_have_default_state()
+        {
+            var options = new MetricsWebTrackingOptions();
+
+            options.IgnoredRoutesRegexPatterns.Should().NotBeNull();
+            options.IgnoredRoutesRegexPatterns.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Setting_ignored_routes_sets_regex_patters()
+        {
+            var patterns = new List<string> { "abc", "123" };
+
+            var options = new MetricsWebTrackingOptions();
+            options.IgnoredRoutesRegexPatterns = patterns;
+
+            options.IgnoredRoutesRegex.Select(r => r.ToString())
+                   .Should().BeEquivalentTo(patterns);
+        }
+
+        [Fact]
+        public void Changing_ignored_routes_changes_regex_patters()
+        {
+            var options = new MetricsWebTrackingOptions();
+            options.IgnoredRoutesRegexPatterns.Add("abc");
+            options.IgnoredRoutesRegexPatterns.Add("123");
+            options.IgnoredRoutesRegexPatterns.Add("route1");
+            options.IgnoredRoutesRegexPatterns.Add("route2");
+
+            options.IgnoredRoutesRegexPatterns.RemoveAt(1);
+            options.IgnoredRoutesRegexPatterns.Remove("route2");
+            options.IgnoredRoutesRegexPatterns.Insert(1, "qwe");
+            options.IgnoredRoutesRegexPatterns[0] = "xyz";
+
+            var expected = new List<string> { "xyz", "qwe", "route1" };
+            options.IgnoredRoutesRegex.Select(r => r.ToString())
+                   .Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void Can_clear_ignored_routes_and_regex()
+        {
+            var options = new MetricsWebTrackingOptions();
+            options.IgnoredRoutesRegexPatterns = new List<string> { "abc", "123" };
+
+            options.IgnoredRoutesRegexPatterns.Clear();
+
+            options.IgnoredRoutesRegex.Should().BeEmpty();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/AppMetrics/AspNetCore/issues/39

Previously `IgnoredRoutesRegexPatterns` was recreated for each request and each middleware (up to three times per request). It is not needed and can have performance implication considering that regexes are `Compiled`. 
My goal was to maintain the same interface which i assume is needed for configuring options using `IOptions` pattern but to keep the state of regex list.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [X] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 

cc @Stealthfox